### PR TITLE
feat: support getter to access getNbBindings result

### DIFF
--- a/include/tensorrt_common/tensorrt_common.hpp
+++ b/include/tensorrt_common/tensorrt_common.hpp
@@ -112,6 +112,7 @@ public:
     bool isInitialized();
 
     nvinfer1::Dims getBindingDimensions(const int32_t index) const;
+    int32_t getNbBindings();
     bool setBindingDimensions(const int32_t index, const nvinfer1::Dims & dimensions) const;
     bool enqueueV2(void ** bindings, cudaStream_t stream, cudaEvent_t * input_consumed);
 

--- a/src/tensorrt_common.cpp
+++ b/src/tensorrt_common.cpp
@@ -214,6 +214,10 @@ nvinfer1::Dims TrtCommon::getBindingDimensions(const int32_t index) const
   return context_->getBindingDimensions(index);
 }
 
+int32_t TrtCommon::getNbBindings()
+{
+  return engine_->getNbBindings();
+}
 
 bool TrtCommon::setBindingDimensions(const int32_t index, const nvinfer1::Dims & dimensions) const
 {


### PR DESCRIPTION
## Related Link
https://tier4.atlassian.net/browse/T4PB-18917

## Description
Add a getter function to access the result of `getNbBindings()`. This modification is required to handle plain models (i.e., models that do not contain EfficientNMS-TRT) in tensorrt_yolox